### PR TITLE
Create data subdirectory upon first execution of download_data.r

### DIFF
--- a/src/download_data.r
+++ b/src/download_data.r
@@ -1,6 +1,9 @@
 library(RCurl)
 PSDS_PATH <- file.path('~', 'statistics-for-data-scientists')
 
+## Create data subdirectory
+dir.create(file.path(PSDS_PATH, 'data'), showWarnings = FALSE)
+
 download_from_google_drive <- function(id, fname, path)
 {
   url <- sprintf("https://drive.google.com/uc?export=download&id=%s", id)


### PR DESCRIPTION
Just encountered an error when executing the `download_data.r` script and modified it so that it creates the required data subdirectory upon first execution. I saw that this was also mentioned by other users in #3 