### PR TITLE
Categorize `loan_data` variable in chapter6.r

### DIFF
--- a/src/chapter6.r
+++ b/src/chapter6.r
@@ -18,6 +18,7 @@ loan3000$outcome <- ordered(loan3000$outcome, levels=c('paid off', 'default'))
 
 loan_data <- read.csv(file.path(PSDS_PATH, 'data', 'loan_data.csv'))
 loan_data <- select(loan_data, -X, -status)
+loan_data$outcome <- ordered(loan_data$outcome, levels=c('paid off', 'default'))
 
 ## KNN
 ## the first row of loan200 is the target data


### PR DESCRIPTION
To fix the error by randomForest.
> Error in y - ymean (chapter6.r#226): non-numeric argument to binary operator

The objective variable of randomForest has to be a binary variable.
